### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in Authorization header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-08 - [Panic in GetUserClaims]
+**Vulnerability:** Denial of Service (DoS) via malformed Authorization header.
+**Learning:** Slicing a string based on prefix length without checking the actual string length can cause a panic.
+**Prevention:** Use safer string manipulation functions like `strings.TrimPrefix` and `strings.TrimSpace` or perform explicit length checks.

--- a/auth.go
+++ b/auth.go
@@ -70,7 +70,7 @@ func (a *Auth) GetUserClaims(ctx context.Context, claims jwt.Claims) (err error)
 
 	token := gctx.GetHeader(authHeaderName)
 	if strings.HasPrefix(token, authHeaderPrefix) { // remove "Bearer "
-		token = token[len(authHeaderPrefix)+1:]
+		token = strings.TrimSpace(strings.TrimPrefix(token, authHeaderPrefix))
 	}
 
 	if err = a.jwt.ParseClaims(token, claims); err != nil {

--- a/panic_safety_test.go
+++ b/panic_safety_test.go
@@ -133,3 +133,21 @@ func TestCtxTraceInject_NoPanic(t *testing.T) {
 		_ = tid
 	}
 }
+
+func TestGetUserClaims_NoPanicOnMalformedHeader(t *testing.T) {
+	a, err := NewAuth([]byte("secret"))
+	require.NoError(t, err)
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request, _ = http.NewRequest("GET", "/", nil)
+	ctx.Request.Header.Set("Authorization", "Bearer") // Exactly "Bearer"
+
+	stdCtx := context.WithValue(context.Background(), CtxKeyGin, ctx)
+
+	require.NotPanics(t, func() {
+		err = a.GetUserClaims(stdCtx, &dummyClaims{})
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Panic in \`GetUserClaims\` when the \`Authorization\` header is exactly "Bearer".
🎯 Impact: Application crash (DoS) if the panic is not recovered, or 500 errors for malformed requests.
🔧 Fix: Used \`strings.TrimPrefix\` and \`strings.TrimSpace\` to safely extract the token, avoiding unsafe slicing.
✅ Verification: Added a test case \`TestGetUserClaims_NoPanicOnMalformedHeader\` to \`panic_safety_test.go\`.

---
*PR created automatically by Jules for task [17985872191464478581](https://jules.google.com/task/17985872191464478581) started by @Laisky*