### PR TITLE
🛡️ Sentinel: [HIGH] Fix cookie security options and domain calculation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-08 - [Cookie Options Silent Failure]
+**Vulnerability:** The `SetCookie` function accepted variadic options (`opts ...SetCookieOption`) but failed to pass them to the underlying `applyOpts` call. This caused security flags like `HttpOnly` and `Secure` to be silently ignored even when explicitly requested by the developer.
+**Learning:** Variadic parameters in Go must be explicitly passed with the `...` syntax (e.g., `applyOpts(opts...)`). Forgetting this leads to the function receiving an empty slice instead of the intended options.
+**Prevention:** Always verify that security-related options are correctly applied in unit tests. Added a permanent `cookie_test.go` to ensure these flags are correctly propagated to the browser.

--- a/cookie.go
+++ b/cookie.go
@@ -2,6 +2,7 @@ package middlewares
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/Laisky/errors/v2"
 	"github.com/Laisky/zap"
@@ -11,7 +12,7 @@ import (
 const (
 	defaultCookiePath     = "/"
 	defaultCookieSecure   = false
-	defaultCookieHTTPOnly = false
+	defaultCookieHTTPOnly = true
 )
 
 type setCookieOption struct {
@@ -25,9 +26,12 @@ func (o *setCookieOption) fillDefault(ctx *gin.Context) *setCookieOption {
 	o.cookieSecure = defaultCookieSecure
 	o.cookieHttpOnly = defaultCookieHTTPOnly
 	if ctx != nil && ctx.Request != nil {
-		o.cookieHost = ctx.Request.Host
-		if ctx.Request.URL != nil && ctx.Request.URL.Port() != "" {
-			o.cookieHost += ":" + ctx.Request.URL.Port()
+		// Cookie domain should not include port.
+		// If Host header contains port, remove it.
+		if host, _, err := net.SplitHostPort(ctx.Request.Host); err == nil {
+			o.cookieHost = host
+		} else {
+			o.cookieHost = ctx.Request.Host
 		}
 	}
 
@@ -99,7 +103,7 @@ func WithCookieHost(host string) SetCookieOption {
 func SetCookie(ctx *gin.Context,
 	name, value string,
 	opts ...SetCookieOption) (err error) {
-	opt, err := new(setCookieOption).fillDefault(ctx).applyOpts()
+	opt, err := new(setCookieOption).fillDefault(ctx).applyOpts(opts...)
 	if err != nil {
 		return err
 	}

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -1,0 +1,72 @@
+package middlewares
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetCookie(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest("GET", "http://example.com/", nil)
+		ctx.Request.Host = "example.com"
+
+		err := SetCookie(ctx, "test_cookie", "test_value")
+		require.NoError(t, err)
+
+		cookies := w.Result().Cookies()
+		require.Len(t, cookies, 1)
+		cookie := cookies[0]
+		require.Equal(t, "test_cookie", cookie.Name)
+		require.Equal(t, "test_value", cookie.Value)
+		require.Equal(t, "/", cookie.Path)
+		require.Equal(t, "example.com", cookie.Domain)
+		require.True(t, cookie.HttpOnly, "HttpOnly should be true by default")
+		require.False(t, cookie.Secure, "Secure should be false by default")
+	})
+
+	t.Run("custom options", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest("GET", "/", nil)
+
+		err := SetCookie(ctx, "test_cookie", "test_value",
+			WithCookieHTTPOnly(false),
+			WithCookieSecure(true),
+			WithCookieMaxAge(3600),
+			WithCookiePath("/api"),
+			WithCookieHost("api.example.com"),
+		)
+		require.NoError(t, err)
+
+		cookies := w.Result().Cookies()
+		require.Len(t, cookies, 1)
+		cookie := cookies[0]
+		require.Equal(t, "test_cookie", cookie.Name)
+		require.Equal(t, "test_value", cookie.Value)
+		require.Equal(t, "/api", cookie.Path)
+		require.Equal(t, "api.example.com", cookie.Domain)
+		require.Equal(t, 3600, cookie.MaxAge)
+		require.False(t, cookie.HttpOnly, "HttpOnly should be false as requested")
+		require.True(t, cookie.Secure, "Secure should be true as requested")
+	})
+
+	t.Run("domain with port", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest("GET", "http://example.com:8080/", nil)
+		ctx.Request.Host = "example.com:8080"
+
+		err := SetCookie(ctx, "test_cookie", "test_value")
+		require.NoError(t, err)
+
+		cookies := w.Result().Cookies()
+		require.Len(t, cookies, 1)
+		cookie := cookies[0]
+		require.Equal(t, "example.com", cookie.Domain, "Domain should not include port")
+	})
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix cookie security options and domain calculation

💡 Vulnerability:
1. SetCookie silently ignored variadic options (opts...), preventing developers from setting HttpOnly, Secure, or MaxAge flags.
2. cookieHost incorrectly included ports and sometimes duplicated them, leading to invalid Domain attributes in Set-Cookie headers.

🎯 Impact:
Cookies could not be properly secured, potentially exposing them to XSS or other attacks even when the developer attempted to enable security flags. Invalid domains caused cookies to be dropped or misattributed by browsers.

🔧 Fix:
- Correctly pass opts... to applyOpts in SetCookie.
- Use net.SplitHostPort to extract only the hostname for cookieHost.
- Set defaultHttpOnly to true for secure-by-default behavior.

✅ Verification:
Added comprehensive tests in cookie_test.go covering default options, custom options application, and domain port stripping. All tests passed with go test -v ./...

---
*PR created automatically by Jules for task [2257022722471894124](https://jules.google.com/task/2257022722471894124) started by @Laisky*